### PR TITLE
Trouble error viewer that uses `tsc` and `eslint`

### DIFF
--- a/nvim/.config/nvim/lua/configs/trouble.lua
+++ b/nvim/.config/nvim/lua/configs/trouble.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+M.Compile = function(packerUse)
+	packerUse({
+		"erikhoj/trouble.nvim",
+		requires = "nvim-tree/nvim-web-devicons",
+		config = function()
+			require("trouble").setup({
+				mode = "tsc",
+			})
+		end,
+	})
+end
+
+return M

--- a/nvim/.config/nvim/lua/plugins.lua
+++ b/nvim/.config/nvim/lua/plugins.lua
@@ -75,6 +75,8 @@ local configs = {
 	"JoosepAlviste/nvim-ts-context-commentstring",
 	-- Comment out lines of code
 	require("configs.nvimcomment"),
+
+	require("configs.trouble"),
 }
 
 -- For boopstraping

--- a/nvim/.config/nvim/todo.md
+++ b/nvim/.config/nvim/todo.md
@@ -1,6 +1,5 @@
 - In insert mode, there's a weird hotkey on S-c that fucks up the cursor.
-- Fix JSDoc completion and newline
+- Fix JSDoc auto completion and newline
 - Make Github Copilot auto-complete not require two keypresses when the auto-complete prompt is open.
 - Make a command/keybinding to quickly source and compile any changes to the vim config.
 - Fix the Eslint LSP server failing to refresh properly when you rename something.
-- Write a Telescope extension that allows us to type-check/eslint the entire project and show errors in a popup.

--- a/scripts/stow-ignore/mac-setup.sh
+++ b/scripts/stow-ignore/mac-setup.sh
@@ -45,3 +45,7 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/too
 
 # Install the latest version of node
 nvm install node 
+
+# Install global NPM packages that are used by the dotfiles
+npm install -g yarn
+yarn global add @aivenio/tsc-output-parser

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -113,5 +113,8 @@ export NVM_DIR="$HOME/.nvm"
   [ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"  # This loads nvm
   [ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
 
+# Make global yarn packages work.
+export PATH="${PATH}:$(yarn global bin)"
+
 # Enable vim mode
 set -o vi


### PR DESCRIPTION
Works by using a fork of `trouble` that has a couple of extra providers implemented.
https://github.com/erikhoj/trouble.nvim